### PR TITLE
Add support for DSD (Declarative Shadow DOM) via `Document.parseHTMLUnsafe`

### DIFF
--- a/example-responses/dsd.html
+++ b/example-responses/dsd.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+	<body>
+    <div>
+      <template shadowrootmode="open">
+        <p><slot></slot></p>
+
+        <style>
+          :host {
+            font-family: Georgia, Times, 'Times New Roman', serif;
+            font-style: italic;
+            border-block-end: 2px dashed currentColor;
+          }
+        </style>
+      </template>
+      This will be formatted according to the stylesheet in shadow DOM.
+    </div>
+  </body>
+</html>

--- a/i-html.js
+++ b/i-html.js
@@ -382,7 +382,12 @@ export class IHTMLElement extends HTMLElement {
       doc.body.append(span)
       children = doc.querySelectorAll('span')
     } else {
-      const doc = new DOMParser().parseFromString(responseText, mime)
+      let doc
+      if (mime == 'text/html' && 'parseHTMLUnsafe' in Document) {
+        doc = Document.parseHTMLUnsafe(responseText)
+      } else {
+        doc = new DOMParser().parseFromString(responseText, mime)
+      }
       this.#setupRefresh(doc.querySelector('meta[http-equiv="refresh"]')?.content || '')
       children = this.#sanitize(doc).querySelectorAll(this.target)
     }

--- a/index.html
+++ b/index.html
@@ -730,6 +730,10 @@
         Support for parsing fragments of HTML which include declarative shadow DOM (DSD) templates via <code>Document.parseHTMLUnsafe</code> <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static">recently entered Baseline 2024 status</a>, so <code>&lt;i-html></code> will use that method of parsing if supported. Older browsers would need a polyfill to handle those cases, otherwise, <code>&lt;i-html></code> will fall back on <code>new DOMParser().parseFromString</code> which does not support DSD.
       </p>
 
+      <p>
+        <strong>Note:</strong> the "unsafe" nomenclature of this API simply means the browser won't perform any sanitization. (Coming soon to the web platform, there will be a `parseHTML` counterpart which does.) But as explained above, <code>&lt;i-html></code> will perform its <em>own</em> sanitizing process unless you choose to opt into potentially dangerous elements.
+      </p>
+
       <div class="demo">
         <i-html id="dsd-example" loading="lazy" src="example-responses/dsd.html">
           ... loading dsd ...

--- a/index.html
+++ b/index.html
@@ -724,6 +724,18 @@
         useful during development.
       </p>
 
+      <h3 id="dsd">Declarative Shadow DOM</h3>
+
+      <p>
+        Support for parsing fragments of HTML which include declarative shadow DOM (DSD) templates via <code>Document.parseHTMLUnsafe</code> <a href="https://developer.mozilla.org/en-US/docs/Web/API/Document/parseHTMLUnsafe_static">recently entered Baseline 2024 status</a>, so <code>&lt;i-html></code> will use that method of parsing if supported. Older browsers would need a polyfill to handle those cases, otherwise, <code>&lt;i-html></code> will fall back on <code>new DOMParser().parseFromString</code> which does not support DSD.
+      </p>
+
+      <div class="demo">
+        <i-html id="dsd-example" loading="lazy" src="example-responses/dsd.html">
+          ... loading dsd ...
+        </i-html>
+      </div>
+
       <h3 id="styling">Styling</h3>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -731,7 +731,7 @@
       </p>
 
       <p>
-        <strong>Note:</strong> the "unsafe" nomenclature of this API simply means the browser won't perform any sanitization. (Coming soon to the web platform, there will be a `parseHTML` counterpart which does.) But as explained above, <code>&lt;i-html></code> will perform its <em>own</em> sanitizing process unless you choose to opt into potentially dangerous elements.
+        <strong>Note:</strong> the "unsafe" nomenclature of this API simply means the browser won't perform any sanitization. (Coming soon to the web platform, there will be a `parseHTML` counterpart which does.) But as explained above, <code>&lt;i-html></code> will perform its <em>own</em> sanitizing process unless you choose to opt into the various `allow` directives.
       </p>
 
       <div class="demo">


### PR DESCRIPTION
Resolves #3 

Let me know what you think of this approach!